### PR TITLE
Travis is currently failing for three reasons:

### DIFF
--- a/pyad/forward_diff.py
+++ b/pyad/forward_diff.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-
 class MultivariateDerivative:
     def __init__(self, variables=None):
         self.variables = variables or {}
@@ -155,7 +154,7 @@ def sqrt(tensor):
 
 
 def cbrt(tensor):
-    return _elementary_op(tensor, np.cbrt, lambda x: 1 / (3 * np.pow(x, 2/3)))
+    return _elementary_op(tensor, np.cbrt, lambda x: 1 / (3 * np.power(x, 2/3)))
 
 
 def power(base, exp):

--- a/pyad/test_pyad.py
+++ b/pyad/test_pyad.py
@@ -1,10 +1,11 @@
 import numpy as np
 import math
-import forward_diff as pyad
+import pyad
 
 ################################
 #       End to End Tests       #
 ################################
+
 def test_case_base_trigonometric():
     '''
     Try some end to end testing using a complex trigonometric function of sin, cos and tan
@@ -24,6 +25,7 @@ def test_case_base_trigonometric():
     assert math.isclose(float(derivative_result.d.variables['x']), true_x_deriv, rel_tol=1e-12)
     assert math.isclose(float(derivative_result.d.variables['y']), true_y_deriv, rel_tol=1e-12)
     assert math.isclose(float(derivative_result.d.variables['z']), true_z_deriv, rel_tol=1e-12)
+
 
 def test_case_base_inversetrig():
     '''
@@ -78,7 +80,7 @@ def test_case_base_log():
 
 def test_case_base_root():
     '''
-    Testing sqaure root and cubic root functions
+    Testing square root and cubic root functions
     '''
     x = pyad.var('x', 4)
     y = pyad.var('y', 8)
@@ -87,7 +89,11 @@ def test_case_base_root():
     # Calculated using numpy
     true_value = 4
     true_x_deriv = 0.25
-    true_y_deriv = 0.01473139127471974
+    true_y_deriv = 0.0833333333333333
+    
+    print(function.value)
+    print(function.d.variables['x'])
+    print(function.d.variables['y'])
 
     assert math.isclose(float(function.value), true_value, rel_tol=1e-12)
     assert math.isclose(float(function.d.variables['x']), true_x_deriv, rel_tol=1e-12)
@@ -150,3 +156,4 @@ def test_get_value_and_deriv_return_Variable():
     assert output_tuple[1].variables == {'x':1}
 
 
+test_case_base_root()

--- a/pyad/test_pyad.py
+++ b/pyad/test_pyad.py
@@ -154,6 +154,3 @@ def test_get_value_and_deriv_return_Variable():
     assert output_tuple[0] == np.array(2)
     assert type(output_tuple[1]) == pyad.MultivariateDerivative
     assert output_tuple[1].variables == {'x':1}
-
-
-test_case_base_root()


### PR DESCRIPTION
1. pytest cannot automatically import pyad
2. The np power function is incorrectly specified
3. The result in the testcase base_root for derivative of y is incorrect

I changed the name of the import to pyad rather than from forward_diff import pyad. There seems to be a difference between importing within the test file (where it needs to be from forward_diff import pyad) and when running tests etc/ externally where it needs to just be import pyad.

Tests were failing with error np.pow does not exist, I changed this to np.power() which appears to have resolved the issue.

Also the test itself still failed due to the value not being correct. I checked the derivative on wolfram alpha and it looks like the value coming back from pyad is correct and the true value specified is incorrect. I updated this to match